### PR TITLE
Text.js: Remove bad restore call.

### DIFF
--- a/src/util/input/text.js
+++ b/src/util/input/text.js
@@ -29,7 +29,6 @@ const textInput = ({
       // Some environments (e.g., cygwin) don't provide a tty
       const e = new Error('stdin lacks setRawMode support')
       e.userError = true
-      restore()
       reject(e)
     }
 


### PR DESCRIPTION
Fixes #25.
The reference error occurs because `restore` is only defined further down in the function.
The `restore` call is not needed, since at this point no user input has been processed.
Even if you moved the definition up, it would still cause a `ReferenceError` due to `setRawMode` not existing, so it's best to just not do it.