### PR TITLE
Use now.json for gcp settings, allow function update

### DIFF
--- a/src/providers/gcp/deploy.js
+++ b/src/providers/gcp/deploy.js
@@ -82,6 +82,13 @@ const deploy = async (ctx: {
     }
   }
 
+  // Example now.json for gcpConfig
+  // {
+  //   name: String,
+  //   timeout: String,
+  //   availableMemoryMb: Number,
+  //   region: String
+  // }
   const { nowJSON: { gcp: gcpConfig } } = desc
 
   const overrides = {
@@ -116,7 +123,7 @@ const deploy = async (ctx: {
     )
   )
 
-  const deploymentId = gcpConfig.functionName || 'now-' + desc.name + '-' + (await uid(10))
+  const deploymentId = gcpConfig.name || 'now-' + desc.name + '-' + (await uid(10))
   const zipFileName = `${deploymentId}.zip`
 
   const { project } = ctx.authConfig.credentials.find(p => p.provider === 'gcp')
@@ -208,8 +215,8 @@ const deploy = async (ctx: {
       },
       body: JSON.stringify({
         name: `projects/${project.id}/locations/${region}/functions/${deploymentId}`,
-        timeout: gcpConfig.timeput || '15s',
-        availableMemoryMb: gcpConfig.memory || 512,
+        timeout: gcpConfig.timeout || '15s',
+        availableMemoryMb: gcpConfig.availableMemoryMb || 512,
         sourceArchiveUrl: `gs://${encodeURIComponent(
           bucketName
         )}/${zipFileName}`,


### PR DESCRIPTION
Initial work to use the `now.json` to customize each single function (name, timeout, memory, etc...).

The most important part is the the name. If you are using a reverse proxy to call the function (like when you want to run Next.JS on a function as it needs to run in the root) you might want to use a custom name for the function without prefix and `uid` suffix. 

This change brings also the second part: **update** the existing function instead of creating a new one every time there is a new deploy.

Example `now.json`:
```json
{
  "gcp": {
    "name": "my-function-name",
    "availableMemoryMb": 256,
    "timeout: "30s"
  }
}
```

This change suits my deployment strategy as I need to update the same function.

Thanks